### PR TITLE
Add sucessfull/error status of provisioning in clusterprofile

### DIFF
--- a/control/netop-org-manager-crd.yaml
+++ b/control/netop-org-manager-crd.yaml
@@ -265,6 +265,8 @@ spec:
                       no_proxy:
                         type: string
                     type: object
+                  cluster_profile_name:
+                    type: string
                   cni:
                     type: string
                   connectivity_checker:
@@ -808,6 +810,8 @@ spec:
                       no_proxy:
                         type: string
                     type: object
+                  cluster_profile_name:
+                    type: string
                   cni:
                     type: string
                   connectivity_checker:
@@ -1294,6 +1298,8 @@ spec:
                       no_proxy:
                         type: string
                     type: object
+                  cluster_profile_name:
+                    type: string
                   cni:
                     type: string
                   connectivity_checker:
@@ -2142,6 +2148,8 @@ spec:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
+                type: string
+              cluster_info_error:
                 type: string
               cluster_network_profile_name:
                 type: string


### PR DESCRIPTION
The netop-fabric-manager update the clusterprofile status incase of successull or failed run of playbooks