### PR TITLE
Shadow resources after delete clusterprofile in managed Case

### DIFF
--- a/control/netop-org-manager-crd.yaml
+++ b/control/netop-org-manager-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clustergroupprofiles.netop.mgr
 spec:
@@ -550,7 +550,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clusterinfoes.netop.mgr
 spec:
@@ -1034,7 +1034,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clusternetworkprofiles.netop.mgr
 spec:
@@ -1521,7 +1521,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clusteroutputs.netop.mgr
 spec:
@@ -1605,7 +1605,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clusterprofiles.netop.mgr
 spec:
@@ -2224,7 +2224,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: clusterstatuses.netop.mgr
 spec:
@@ -2280,7 +2280,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: fabricinfras.netop.mgr
 spec:
@@ -2543,7 +2543,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: servicemeshtopologies.netop.mgr
 spec:
@@ -2585,6 +2585,62 @@ spec:
             type: object
           status:
             description: ServiceMeshTopologyStatus defines the observed state of ServiceMeshTopology
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: shadowresources.netop.mgr
+spec:
+  group: netop.mgr
+  names:
+    kind: ShadowResource
+    listKind: ShadowResourceList
+    plural: shadowresources
+    singular: shadowresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ShadowResource is the Schema for the shadowresources API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ShadowResourceSpec defines the desired state of ShadowResource
+            properties:
+              acc_provision_input:
+                type: string
+              deploy_manifest:
+                type: string
+            type: object
+          status:
+            description: ShadowResourceStatus defines the observed state of ShadowResource
+            properties:
+              success:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: boolean
             type: object
         type: object
     served: true


### PR DESCRIPTION
The feature provides backup of resources in case of managed scenario If the netop-fabric-manager crashes or come to halt, user can refer the acc_provsion_input file and deployment manifests resources to know about the generated output for troubleshooting